### PR TITLE
Fix CID in simulator script for MacOS

### DIFF
--- a/scripts/sendSimulControl.sh
+++ b/scripts/sendSimulControl.sh
@@ -22,7 +22,11 @@ url="http://$hostn/control"
 echo ""
 echo "Send $fname to $url"
 sed "s/co2sensor/${stype}/g" $fname > new.json
-sed -i "s/C100/${cid}/g" new.json
+if [[ $(uname) == "Darwin" ]] ; then
+  sed -i '' "s/C100/${cid}/g" new.json
+else
+  sed -i "s/C100/${cid}/g" new.json
+fi
 
 echo "POST the following data:"
 cat new.json


### PR DESCRIPTION
The `sed` command that replaces the container ID (`cid`) fails on Mac OS.

The proposed fix makes it work on BSD (Mac OS) as well as on Linux.