### PR TITLE
SCRAM credentials for ES v10

### DIFF
--- a/scoring-mp/chart/scoringmp/values.yaml
+++ b/scoring-mp/chart/scoringmp/values.yaml
@@ -44,7 +44,7 @@ kafka:
     bootstrapPath: /opt/ol/wlp/usr/servers/defaultServer/bootstrap.properties
     truststoreRequired: false
     truststorePath: /config/resources/security
-    truststoreSecret: es-truststore-jks
+    truststoreSecret: eventstreams-truststore
 predictiveModel:
   predictionsEnabled: false
   predictiveModelConfigMap: predictive-model-configmap

--- a/scoring-mp/src/main/resources/META-INF/microprofile-config.properties
+++ b/scoring-mp/src/main/resources/META-INF/microprofile-config.properties
@@ -26,14 +26,20 @@ mp.messaging.outgoing.containers.value.serializer=org.apache.kafka.common.serial
 # bootstrap server is the only config needed for plain insercure local kafka instance
 #mp.messaging.connector.liberty-kafka.bootstrap.servers=
 
-# If connecting to Event Streams on IBM Cloud or to any Kafka deployment with SSL security
+# If connecting to Event Streams on IBM Cloud
 # mp.messaging.connector.liberty-kafka.security.protocol=SASL_SSL
 # mp.messaging.connector.liberty-kafka.ssl.protocol=TLSv1.2
 # mp.messaging.connector.liberty-kafka.sasl.mechanism=PLAIN
-# Make sure you set the username and API key at the end
-# mp.messaging.connector.liberty-kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<USERNAME>" password="<API_KEY>";
+# Make sure you set the Kafka user and password at the end
+# mp.messaging.connector.liberty-kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="<KAFKA_USER>" password="<KAFKA_PASSWORD>";
 
-# If connecting to Event Streams in OpenShift that requires certificates
+# If connecting to Event Streams on OpenShift
+# mp.messaging.connector.liberty-kafka.security.protocol=SASL_SSL
+# mp.messaging.connector.liberty-kafka.ssl.protocol=TLSv1.2
+# mp.messaging.connector.liberty-kafka.sasl.mechanism=SCRAM-SHA-512
+# mp.messaging.connector.liberty-kafka.ssl.truststore.type=PKCS12
+# Make sure you set the Kafka User and password at the end
+# mp.messaging.connector.liberty-kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="<KAFKA_USER>" password="<KAFKA_PASSWORD>";
 # Location for the truststore within the container
 # mp.messaging.connector.liberty-kafka.ssl.truststore.location=
 # Password for the truststore

--- a/simulator/chart/kcontainer-reefer-simulator/templates/deployment.yaml
+++ b/simulator/chart/kcontainer-reefer-simulator/templates/deployment.yaml
@@ -68,11 +68,16 @@ spec:
                 name: "{{ .Values.kafka.topicsConfigMap }}"
                 key: reeferTelemetryTopic
           {{- if .Values.eventstreams.enabled }}
-          - name: KAFKA_APIKEY
+          - name: KAFKA_USER
             valueFrom:
               secretKeyRef:
-                name: "{{ .Values.eventstreams.apikeyConfigMap }}"
-                key: binding
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: username
+          - name: KAFKA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ .Values.eventstreams.esCredSecret }}"
+                key: password
           - name: KAFKA_CERT
             valueFrom:
               secretKeyRef:

--- a/simulator/chart/kcontainer-reefer-simulator/values.yaml
+++ b/simulator/chart/kcontainer-reefer-simulator/values.yaml
@@ -22,8 +22,8 @@ ingress:
 kafka:
   brokersConfigMap: kafka-brokers
   topicsConfigMap: kafka-topics
-  capemSecret: es-cert-pem
+  capemSecret: eventstreams-cert-pem
 eventstreams:
   enabled: true
-  apikeyConfigMap: eventstreams-apikey
+  esCredSecret: eventstreams-cred
 serviceAccountName: kcontainer-runtime

--- a/simulator/infrastructure/EventBackboneConfiguration.py
+++ b/simulator/infrastructure/EventBackboneConfiguration.py
@@ -15,7 +15,7 @@ def getKafkaUser():
     return KAFKA_USER
 
 def isSecured():
-    return KAFKA_APIKEY != ''
+    return KAFKA_PASSWORD != ''
 
 def isEncrypted():
     #return KAFKA_CERT != ''

--- a/simulator/infrastructure/EventBackboneConfiguration.py
+++ b/simulator/infrastructure/EventBackboneConfiguration.py
@@ -1,16 +1,20 @@
 import os
 
 KAFKA_BROKERS = os.getenv('KAFKA_BROKERS','localhost:9092')
-KAFKA_APIKEY = os.getenv('KAFKA_APIKEY','')
+KAFKA_PASSWORD = os.getenv('KAFKA_PASSWORD','')
+KAFKA_USER = os.getenv('KAFKA_USER','')
 KAFKA_CERT = os.getenv('KAFKA_CERT','')
 
 def getBrokerEndPoints():
     return KAFKA_BROKERS
 
-def getEndPointAPIKey():
-    return KAFKA_APIKEY
+def getKafkaPassword():
+    return KAFKA_PASSWORD
 
-def hasAPIKey():
+def getKafkaUser():
+    return KAFKA_USER
+
+def isSecured():
     return KAFKA_APIKEY != ''
 
 def isEncrypted():

--- a/simulator/infrastructure/MetricsEventsProducer.py
+++ b/simulator/infrastructure/MetricsEventsProducer.py
@@ -12,11 +12,16 @@ class MetricsEventsProducer:
                 'bootstrap.servers':  EventBackboneConfiguration.getBrokerEndPoints(),
                 'group.id': groupID,
         }
-        if (EventBackboneConfiguration.hasAPIKey()):
+        if (EventBackboneConfiguration.isSecured()):
             options['security.protocol'] = 'SASL_SSL'
-            options['sasl.mechanisms'] = 'PLAIN'
-            options['sasl.username'] = 'token'
-            options['sasl.password'] = EventBackboneConfiguration.getEndPointAPIKey()
+            # If we are connecting to ES on IBM Cloud, the SASL mechanism is plain
+            if (EventBackboneConfiguration.getKafkaUser() == 'token'):
+                options['sasl.mechanisms'] = 'PLAIN'
+            # If we are connecting to ES on OCP, the SASL mechanism is scram-sha-512
+            else:
+                options['sasl.mechanisms'] = 'SCRAM-SHA-512'
+            options['sasl.username'] = EventBackboneConfiguration.getKafkaUser()
+            options['sasl.password'] = EventBackboneConfiguration.getKafkaPassword()
         if (EventBackboneConfiguration.isEncrypted()):
             options['ssl.ca.location'] = EventBackboneConfiguration.getKafkaCertificate()
         print("Kafka options are:")


### PR DESCRIPTION
Refactoring to allow new authentication mechanism in ES v10 that uses SCRAM. There is also some refactoring on the names for the secrets/configmaps that this microservices will be loading config from.

This is one of the changes suggested in https://github.com/ibm-cloud-architecture/refarch-kc/issues/119